### PR TITLE
Refactor `Generate.tsx` page file

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -47,11 +47,7 @@ function App() {
           <Route path="/" element={<Home />} />
           <Route
             path="/generate"
-            element={
-              <Generate
-                setShowModelList={setShowModelList}
-              />
-            }
+            element={<Generate setShowModelList={setShowModelList} />}
           />
           <Route path="/knowledge" element={<Knowledge />}>
             <Route path="/knowledge" element={<KnowledgeTypeSelectionView />} />

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -48,7 +48,7 @@ export function Button({
     // Safely handle a null target
     <Link
       to={to ?? ""}
-      className={`flex ${itemsRow ? "flex-row" : "flex-col"} text-center gap-2 rounded-lg px-4 py-2 border transition-colors ease-in-out duration-300 ${buttonClass[type]} ${className} shadow-lg`}
+      className={`flex ${itemsRow ? "flex-row" : "flex-col"} text-center gap-2 rounded-lg px-4 py-2 border transition-all ease-in-out duration-300 ${buttonClass[type]} ${className} shadow-lg`}
       onClick={onClick}
     >
       {children}

--- a/frontend/src/features/generate/components/BlogCard.tsx
+++ b/frontend/src/features/generate/components/BlogCard.tsx
@@ -1,0 +1,81 @@
+import { Card } from "../../../components/Card";
+import { FaExpandArrowsAlt } from "react-icons/fa";
+import { ModelBadge } from "../../../features/models/ModelBadge";
+import { Button } from "../../../components/Button";
+import { FaCopy } from "react-icons/fa";
+import { BlogSkeleton } from "../../../components/BlogSkeleton";
+import Markdown from "react-markdown";
+
+export const BlogCard = ({
+  generatedBlog,
+  isGenerating,
+  wordCount,
+  expanded,
+  setExpanded,
+  setShowModelList,
+}: {
+  generatedBlog: string;
+  isGenerating: boolean;
+  wordCount: number;
+  expanded: boolean;
+  setExpanded: (expanded: boolean) => void;
+  setShowModelList: (show: boolean) => void;
+}) => {
+  const handleCopy = () => {
+    navigator.clipboard.writeText(generatedBlog);
+  };
+
+  return (
+    <Card
+      className={`flex flex-col ${
+        expanded ? "lg:w-11/12" : "lg:w-2/3"
+      } gap-2 h-full overflow-y-hidden transition-all duration-300 pb-2`}
+      overrideDims={true}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <FaExpandArrowsAlt onClick={() => setExpanded(!expanded)} />
+          <h2 className="text-lg font-semibold">AI Output</h2>
+        </div>
+        <div
+          className={`${
+            wordCount > 1 ? "opacity-100" : "opacity-0"
+          } transition-opacity duration-1000 text-sm text-gray-400 rounded-full bg-gray-700 px-2 py-1 border border-white/10`}
+        >
+          {wordCount} words
+        </div>
+        <div className="flex flex-col transition-all duration-300">
+          <ModelBadge
+            activeModel={"GPT-4.1"}
+            onClick={() => setShowModelList(true)}
+          />
+        </div>
+        {generatedBlog && (
+          <div className="flex items-center gap-2 absolute bottom-0 right-0 bg-gray-950/50 backdrop-blur-lg p-2 rounded-lg">
+            <Button
+              type="primary"
+              onClick={handleCopy}
+              itemsRow={true}
+              className="opacity-50 hover:opacity-100 transition-opacity duration-300 backdrop-blur-lg aspect-square items-center justify-center"
+            >
+              <FaCopy className="text-base" />
+            </Button>
+          </div>
+        )}
+      </div>
+      <div className="w-full h-px bg-gray-700 "></div>
+      <div className="flex flex-col h-full pb-4 overflow-y-auto">
+        {!generatedBlog ? (
+          <div className="mb-2 text-sm text-gray-400">
+            Your blog post will be generated here!
+            <BlogSkeleton isGenerating={isGenerating} />
+          </div>
+        ) : (
+          <div className="markdown flex flex-col flex-1 gap-2 overflow-y-auto h-full pt-2 relative">
+            <Markdown>{generatedBlog}</Markdown>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+};

--- a/frontend/src/features/generate/components/BlogOverlayButtons.tsx
+++ b/frontend/src/features/generate/components/BlogOverlayButtons.tsx
@@ -1,6 +1,6 @@
 // GlobalOverlayButtons.tsx
 import { createPortal } from "react-dom";
-import { FaCheck, FaChevronDown, FaChevronUp, FaCopy } from "react-icons/fa";
+import { FaChevronDown, FaChevronUp, FaCopy } from "react-icons/fa";
 import { Button } from "../../../components/Button";
 import { useEffect, useState } from "react";
 

--- a/frontend/src/features/generate/components/BlogOverlayButtons.tsx
+++ b/frontend/src/features/generate/components/BlogOverlayButtons.tsx
@@ -1,0 +1,94 @@
+// GlobalOverlayButtons.tsx
+import { createPortal } from "react-dom";
+import { FaCheck, FaChevronDown, FaChevronUp, FaCopy } from "react-icons/fa";
+import { Button } from "../../../components/Button";
+import { useEffect, useState } from "react";
+
+export const BlogOverlayButtons = ({
+  isGenerating,
+  scrollInterupted,
+  setScrollInterupted,
+  generatedBlog,
+}: {
+  isGenerating: boolean;
+  scrollInterupted: boolean;
+  setScrollInterupted: (scrollInterupted: boolean) => void;
+  generatedBlog: string;
+}) => {
+  const handleCopy = () => {
+    navigator.clipboard.writeText(generatedBlog);
+    setIsCopied(true);
+  };
+
+  const [scrollUpVisible, setScrollUpVisible] = useState(false);
+  const [copyVisible, setCopyVisible] = useState(false);
+  const [isCopied, setIsCopied] = useState(false);
+
+  useEffect(() => {
+    if (isCopied) {
+      setTimeout(() => {
+        setIsCopied(false);
+      }, 2000);
+    }
+  }, [isCopied]);
+
+  useEffect(() => {
+    if (generatedBlog.length > 1) {
+      setCopyVisible(true);
+    }
+  }, [generatedBlog]);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setScrollUpVisible(window.scrollY > window.innerHeight * 0.5);
+    };
+    window.addEventListener("scroll", handleScroll);
+  }, []);
+
+  return createPortal(
+    <div className="lg:hidden">
+      {isGenerating && scrollInterupted && (
+        <div
+          className="lg:hidden fixed bottom-4 left-1/2 transform -translate-x-1/2 z-50  mr-2 opacity-50 hover:opacity-100 transition-opacity duration-300 aspect-square items-center justify-center rounded-full bg-gray-950/90 p-4"
+          onClick={() => {
+            setScrollInterupted(false);
+          }}
+        >
+          <FaChevronDown className="text-3xl" />
+        </div>
+      )}
+      <div className="fixed bottom-4 right-4 flex flex-col gap-2 z-50">
+        <Button
+          type="primary"
+          onClick={() => {
+            window.scrollTo({
+              top: 0,
+              behavior: "smooth",
+            });
+            setScrollInterupted(true);
+            setScrollUpVisible(true);
+          }}
+          className={`${
+            scrollUpVisible ? "opacity-50 hover:opacity-100" : "opacity-0"
+          } transition-opacity duration-300 aspect-square items-center justify-center`}
+        >
+          <FaChevronUp className="text-base" />
+        </Button>
+        <Button
+          type="primary"
+          onClick={handleCopy}
+          className={`${
+            isCopied
+              ? "opacity-100"
+              : "opacity-50 hover:opacity-100 aspect-square"
+            }  items-center justify-center transition-all duration-300
+          ${!copyVisible && "opacity-0"}`}
+        >
+          <FaCopy className="text-base" />
+          {isCopied && "Text Copied to Clipboard"}
+        </Button>
+      </div>
+    </div>,
+    document.getElementById("portal-root")!
+  );
+};

--- a/frontend/src/features/generate/components/BlogOverlayButtons.tsx
+++ b/frontend/src/features/generate/components/BlogOverlayButtons.tsx
@@ -43,6 +43,9 @@ export const BlogOverlayButtons = ({
       setScrollUpVisible(window.scrollY > window.innerHeight * 0.5);
     };
     window.addEventListener("scroll", handleScroll);
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
   }, []);
 
   return createPortal(

--- a/frontend/src/features/generate/components/BlogTopicForm.tsx
+++ b/frontend/src/features/generate/components/BlogTopicForm.tsx
@@ -3,6 +3,7 @@ import { Card } from "../../../components/Card";
 import { FaList, FaTimes } from "react-icons/fa";
 import { useState } from "react";
 import { Button } from "../../../components/Button";
+import { FormValues } from "../../../types/blog";
 
 /**
  * A form component for generating blog content with topic selection and input options.
@@ -28,21 +29,9 @@ export const BlogTopicForm = ({
   handleGenerate,
   isGenerating,
 }: {
-  formValues: {
-    topic: string;
-    details: string;
-    keywords: string[];
-  };
-  setFormValues: (formValues: {
-    topic: string;
-    details: string;
-    keywords: string[];
-  }) => void;
-  handleGenerate: (formValues: {
-    topic: string;
-    details: string;
-    keywords: string[];
-  }) => Promise<void>;
+  formValues: FormValues;
+  setFormValues: (formValues: FormValues) => void;
+  handleGenerate: (formValues: FormValues) => Promise<void>;
   isGenerating: boolean;
 }) => {
   const [selectedOption, setSelectedOption] = useState<string>("");

--- a/frontend/src/features/generate/components/BlogTopicForm.tsx
+++ b/frontend/src/features/generate/components/BlogTopicForm.tsx
@@ -48,6 +48,8 @@ export const BlogTopicForm = ({
     });
   };
 
+
+
   return (
     <div
       className={`flex flex-col ${

--- a/frontend/src/features/generate/components/BlogTopicForm.tsx
+++ b/frontend/src/features/generate/components/BlogTopicForm.tsx
@@ -33,12 +33,20 @@ export const BlogTopicForm = ({
     details: string;
     keywords: string[];
   };
-  setFormValues: (formValues: { topic: string; details: string; keywords: string[] }) => void;
-  handleGenerate: () => void;
+  setFormValues: (formValues: {
+    topic: string;
+    details: string;
+    keywords: string[];
+  }) => void;
+  handleGenerate: (formValues: {
+    topic: string;
+    details: string;
+    keywords: string[];
+  }) => Promise<void>;
   isGenerating: boolean;
 }) => {
   const [selectedOption, setSelectedOption] = useState<string>("");
-  
+
   const handleOptionClick = (option: string) => {
     setSelectedOption(option);
   };
@@ -50,7 +58,10 @@ export const BlogTopicForm = ({
 
   const handleKeywordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
-    setFormValues({ ...formValues, [name]: value.split(",").map((keyword) => keyword.trim()) });
+    setFormValues({
+      ...formValues,
+      [name]: value.split(",").map((keyword) => keyword.trim()),
+    });
   };
 
   return (
@@ -190,7 +201,9 @@ export const BlogTopicForm = ({
                 <div className="flex">
                   <FaTimes
                     className={`${
-                      formValues.keywords.length > 0 ? "opacity-100" : "opacity-0"
+                      formValues.keywords.length > 0
+                        ? "opacity-100"
+                        : "opacity-0"
                     } text-gray-400 text-sm cursor-pointer transition-all duration-300`}
                     onClick={() =>
                       setFormValues({ ...formValues, keywords: [] })
@@ -203,7 +216,7 @@ export const BlogTopicForm = ({
           <Button
             type={isGenerating ? "disabled" : "accent"}
             className="w-full"
-            onClick={handleGenerate}
+            onClick={() => handleGenerate(formValues)}
           >
             {isGenerating ? "Generating..." : "Generate Blog"}
           </Button>

--- a/frontend/src/features/generate/components/BlogTopicForm.tsx
+++ b/frontend/src/features/generate/components/BlogTopicForm.tsx
@@ -2,7 +2,6 @@ import { FaWandMagicSparkles } from "react-icons/fa6";
 import { Card } from "../../../components/Card";
 import { FaList, FaTimes } from "react-icons/fa";
 import { useState } from "react";
-import { Button } from "../../../components/Button";
 import { FormValues } from "../../../types/blog";
 
 /**
@@ -26,13 +25,9 @@ import { FormValues } from "../../../types/blog";
 export const BlogTopicForm = ({
   formValues,
   setFormValues,
-  handleGenerate,
-  isGenerating,
 }: {
   formValues: FormValues;
   setFormValues: (formValues: FormValues) => void;
-  handleGenerate: (formValues: FormValues) => Promise<void>;
-  isGenerating: boolean;
 }) => {
   const [selectedOption, setSelectedOption] = useState<string>("");
 
@@ -202,13 +197,6 @@ export const BlogTopicForm = ({
               </div>
             </Card>
           </div>
-          <Button
-            type={isGenerating ? "disabled" : "accent"}
-            className="w-full"
-            onClick={() => handleGenerate(formValues)}
-          >
-            {isGenerating ? "Generating..." : "Generate Blog"}
-          </Button>
         </div>
       )}
     </div>

--- a/frontend/src/hooks/useBlogGeneration.ts
+++ b/frontend/src/hooks/useBlogGeneration.ts
@@ -1,0 +1,67 @@
+import { useState } from "react";
+
+interface FormValues {
+  topic: string;
+  details: string;
+  keywords: string[];
+}
+
+interface UseBlogGenerationReturn {
+  generatedBlog: string;
+  isGenerating: boolean;
+  handleGenerate: (formValues: FormValues) => Promise<void>;
+  handleCopy: () => void;
+}
+
+export const useBlogGeneration = (): UseBlogGenerationReturn => {
+  const apiBaseUrl = import.meta.env.VITE_APP_API_URL;
+  const [generatedBlog, setGeneratedBlog] = useState<string>(() => {
+    return localStorage.getItem("generatedBlog") || "";
+  });
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  const handleGenerate = async (formValues: FormValues) => {
+    setIsGenerating(true);
+    setGeneratedBlog("");
+
+    const response = await fetch(`${apiBaseUrl}/api/v1/generate`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        topic: formValues.topic,
+        details: formValues.details,
+        keywords: formValues.keywords,
+      }),
+    });
+
+    if (!response.body) {
+      setIsGenerating(false);
+      return;
+    }
+
+    setGeneratedBlog("");
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+
+    while (reader) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      const text = decoder.decode(value, { stream: true });
+      setGeneratedBlog((prev) => prev + text);
+    }
+    setIsGenerating(false);
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(generatedBlog);
+  };
+
+  return {
+    generatedBlog,
+    isGenerating,
+    handleGenerate,
+    handleCopy,
+  };
+};

--- a/frontend/src/hooks/useBlogGeneration.ts
+++ b/frontend/src/hooks/useBlogGeneration.ts
@@ -1,10 +1,5 @@
 import { useState } from "react";
-
-interface FormValues {
-  topic: string;
-  details: string;
-  keywords: string[];
-}
+import { FormValues } from "../types/blog";
 
 interface UseBlogGenerationReturn {
   generatedBlog: string;

--- a/frontend/src/pages/Generate.tsx
+++ b/frontend/src/pages/Generate.tsx
@@ -16,6 +16,7 @@ import { UnderDev } from "../components/UnderDev";
 import { Button } from "../components/Button";
 import { useBlogGeneration } from "../hooks/useBlogGeneration";
 import { FormValues } from "../types/blog";
+import { BlogOverlayButtons } from "../features/generate/components/BlogOverlayButtons";
 
 /**
  * The Generate page component that provides a multi-step blog generation workflow.
@@ -62,6 +63,13 @@ export const Generate = ({
   const { generatedBlog, isGenerating, handleGenerate, handleCopy } =
     useBlogGeneration();
 
+  const handleGenerateClick = () => {
+    if (formValues.topic === "" || isGenerating) {
+      return;
+    }
+    setScrollInterupted(false);
+    handleGenerate(formValues);
+  };
   // Effects
   useEffect(() => {
     localStorage.setItem("generatedBlog", generatedBlog);
@@ -194,14 +202,17 @@ export const Generate = ({
             {useContent(activeStep)}
             <div className="w-full h-px bg-gray-700 my-4"></div>
             <div className="flex items-center gap-2 justify-between">
-              {" "}
+              {/* Generate Button */}
               <Button
                 type={isGenerating ? "disabled" : "accent"}
-                className="w-full"
-                onClick={() => handleGenerate(formValues)}
+                className={`w-full transition-all duration-300 ${
+                  formValues.topic !== "" ? "opacity-100" : "opacity-0"
+                }`}
+                onClick={handleGenerateClick}
               >
                 {isGenerating ? "Generating..." : "Generate Blog"}
               </Button>
+              {/* Navigation Buttons */}
               <div className="flex items-center gap-2 justify-between">
                 <Button
                   type="primary"
@@ -274,6 +285,12 @@ export const Generate = ({
           </div>
         </Card>
       </div>
+      <BlogOverlayButtons
+        isGenerating={isGenerating}
+        scrollInterupted={scrollInterupted}
+        setScrollInterupted={setScrollInterupted}
+        generatedBlog={generatedBlog}
+      />
     </PageContainer>
   );
 };

--- a/frontend/src/pages/Generate.tsx
+++ b/frontend/src/pages/Generate.tsx
@@ -10,12 +10,7 @@ import { FaCopy, FaExpandArrowsAlt } from "react-icons/fa";
 import { UnderDev } from "../components/UnderDev";
 import { Button } from "../components/Button";
 import { useBlogGeneration } from "../hooks/useBlogGeneration";
-
-interface FormValues {
-  topic: string;
-  details: string;
-  keywords: string[];
-}
+import { FormValues } from "../types/blog";
 
 /**
  * The Generate page component that provides a multi-step blog generation workflow.

--- a/frontend/src/pages/Generate.tsx
+++ b/frontend/src/pages/Generate.tsx
@@ -156,7 +156,7 @@ export const Generate = ({
   const stepComponents = steps.map((step) => step.component);
 
   const useContent = (step: number) => {
-    return step <= steps.length ? stepComponents[step] : null;
+    return step < steps.length ? stepComponents[step] : null;
   };
 
   return (

--- a/frontend/src/pages/Generate.tsx
+++ b/frontend/src/pages/Generate.tsx
@@ -2,21 +2,14 @@ import { Card } from "../components/Card";
 import { PageContainer } from "../features/page_container/PageContainer";
 import { GenerateWorkflow } from "../features/generate/components/GenerateWorkflow";
 import { useState, useEffect } from "react";
-import { ModelBadge } from "../features/models/ModelBadge";
-import { BlogSkeleton } from "../components/BlogSkeleton";
 import { BlogTopicForm } from "../features/generate/components/BlogTopicForm";
-import Markdown from "react-markdown";
-import {
-  FaArrowLeft,
-  FaArrowRight,
-  FaCopy,
-  FaExpandArrowsAlt,
-} from "react-icons/fa";
+import { FaArrowLeft, FaArrowRight } from "react-icons/fa";
 import { UnderDev } from "../components/UnderDev";
 import { Button } from "../components/Button";
 import { useBlogGeneration } from "../hooks/useBlogGeneration";
 import { FormValues } from "../types/blog";
 import { BlogOverlayButtons } from "../features/generate/components/BlogOverlayButtons";
+import { BlogCard } from "../features/generate/components/BlogCard";
 
 /**
  * The Generate page component that provides a multi-step blog generation workflow.
@@ -233,57 +226,14 @@ export const Generate = ({
           </div>
         </Card>
         {/* Right Side */}
-        <Card
-          className={`flex flex-col ${
-            expanded ? "lg:w-11/12" : "lg:w-2/3"
-          } gap-2 h-full overflow-y-hidden transition-all duration-300 pb-2`}
-          overrideDims={true}
-        >
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <FaExpandArrowsAlt onClick={() => setExpanded(!expanded)} />
-              <h2 className="text-lg font-semibold">AI Output</h2>
-            </div>
-            <div
-              className={`${
-                wordCount > 1 ? "opacity-100" : "opacity-0"
-              } transition-opacity duration-1000 text-sm text-gray-400 rounded-full bg-gray-700 px-2 py-1 border border-white/10`}
-            >
-              {wordCount} words
-            </div>
-            <div className="flex flex-col transition-all duration-300">
-              <ModelBadge
-                activeModel={"GPT-4.1"}
-                onClick={() => setShowModelList(true)}
-              />
-            </div>
-            {generatedBlog && (
-              <div className="flex items-center gap-2 absolute bottom-0 right-0 bg-gray-950/50 backdrop-blur-lg p-2 rounded-lg">
-                <Button
-                  type="primary"
-                  onClick={handleCopy}
-                  itemsRow={true}
-                  className="opacity-50 hover:opacity-100 transition-opacity duration-300 backdrop-blur-lg aspect-square items-center justify-center"
-                >
-                  <FaCopy className="text-base" />
-                </Button>
-              </div>
-            )}
-          </div>
-          <div className="w-full h-px bg-gray-700 "></div>
-          <div className="flex flex-col h-full pb-4 overflow-y-auto">
-            {!generatedBlog ? (
-              <div className="mb-2 text-sm text-gray-400">
-                Your blog post will be generated here!
-                <BlogSkeleton isGenerating={isGenerating} />
-              </div>
-            ) : (
-              <div className="markdown flex flex-col flex-1 gap-2 overflow-y-auto h-full pt-2 relative">
-                <Markdown>{generatedBlog}</Markdown>
-              </div>
-            )}
-          </div>
-        </Card>
+        <BlogCard
+          generatedBlog={generatedBlog}
+          isGenerating={isGenerating}
+          wordCount={wordCount}
+          expanded={expanded}
+          setExpanded={setExpanded}
+          setShowModelList={setShowModelList}
+        />
       </div>
       <BlogOverlayButtons
         isGenerating={isGenerating}

--- a/frontend/src/types/blog.ts
+++ b/frontend/src/types/blog.ts
@@ -1,0 +1,5 @@
+export interface FormValues {
+  topic: string;
+  details: string;
+  keywords: string[];
+}


### PR DESCRIPTION
# Refactor `Generate.tsx` Page File

## Overview:
This PR begins the refactoring of `frontend>pages>Generate.tsx`. The file grew large as it was undergoing testing and iteration, and it was time to break it apart.

For now, this involves separating the various card components (the workflow, the generated blog, and the blog form). Additionally, TypeScript type interfaces for form data, steps (for the stepper) were defined and broken out. Finally, `useGenerate` hook has been moved out as well.

## Additions:
There were some minor additions, mainly to make the refactor easier. Generate and navigation buttons were moved out of the blog form content components and into the parent container component. Overlay buttons were added to the parent to control the blog generation interactions.